### PR TITLE
follow #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ accumulate lots of metadata about a binding (e.g. name, type, location etc.).
 
 `searchdocs` takes three keyword arguments:
 - `loaded::Bool = true` will search only packages in the current session, while `loaded = false` will search in *all* locally installed packages (actually only those in `Pkg.installed()`). Requires a call to `DocSeeker.createdocsdb()` beforehand.
-- `mod::String = "Main"` will restrict the search to the given module -- by default every loaded package will be searched.
+- `mod::Module = Main` will filter out bindings that can't be reached from the given module -- by default every loaded package will be searched.
 - `maxreturns::Int = DocSeeker.MAX_RETURN_SIZE = 20` will specify the maximum number of the results
 - `exportedonly::Bool = false` will search all names a module has, while `exportedonly = true` only takes exported names into consideration.
 - `name_only::Bool = false` will respect equalities between `needle` and both a binding's name and its doc text, while `name_only = true` only respects a equality to a binding's name.

--- a/src/introspective.jl
+++ b/src/introspective.jl
@@ -26,16 +26,28 @@ function dynamicsearch(needle::AbstractString, mod::Module = Main,
     if mod == Main
       x -> x[2].exported
     else
-      let mod = mod
-        x -> x[2].exported && isdefined(mod, Symbol(x[2].mod))
+      let mod = mod, modstr = modstr
+        x -> begin
+          # filters out unexported bindings
+          x[2].exported &&
+          # filters bindings that can be reached from `mod`
+          (
+            isdefined(mod, Symbol(x[2].mod)) ||
+            modstr == x[2].mod # needed since submodules are not defined in themselves
+          )
+        end
       end
     end
   else
     if mod == Main
       x -> true
     else
-      let mod = mod
-        x -> isdefined(mod, Symbol(x[2].mod))
+      let mod = mod, modstr = modstr
+        x -> begin
+          # filters bindings that can be reached from `mod`
+          isdefined(mod, Symbol(x[2].mod)) ||
+          modstr == x[2].mod # needed since submodules are not defined in themselves
+        end
       end
     end
   end

--- a/src/introspective.jl
+++ b/src/introspective.jl
@@ -10,6 +10,11 @@ function searchdocs(needle::AbstractString; loaded::Bool = true, mod::Module = M
            dynamicsearch(needle, mod, exportedonly, maxreturns, name_only, loaddocsdb())
 end
 
+# TODO:
+# We may want something like `CodeTools.getmodule` here, so that we can accept `mod` as `String`:
+# - then we can correctly score bindings even in unloaded packages
+# - it would make `isdefined` checks below more robust -- currently it won't work when e.g.
+#   we try to find `Atom.JunoDebugger.isdebugging` given `mod == Atom`
 function dynamicsearch(needle::AbstractString, mod::Module = Main,
                        exportedonly::Bool = false, maxreturns::Int = MAX_RETURN_SIZE,
                        name_only::Bool = false, docs::Vector{DocObj} = alldocs(mod))

--- a/src/introspective.jl
+++ b/src/introspective.jl
@@ -2,7 +2,7 @@ mutable struct GlobalCache
   time::Float64
   cache::Vector{DocObj}
 end
-const CACHE = GlobalCache(time(), DocObj[])
+const CACHE = GlobalCache(0.0, DocObj[])
 
 CACHETIMEOUT = 30 # s
 

--- a/src/introspective.jl
+++ b/src/introspective.jl
@@ -1,4 +1,9 @@
-CACHE = (0, [])
+mutable struct GlobalCache
+  time::Float64
+  cache::Vector{DocObj}
+end
+const CACHE = GlobalCache(time(), DocObj[])
+
 CACHETIMEOUT = 30 # s
 
 MAX_RETURN_SIZE = 20 # how many results to return at most
@@ -89,12 +94,8 @@ end
 
 Find all docstrings in all currently loaded Modules.
 """
-function alldocs(topmod = Main)
-  global CACHE
-
-  if (time() - CACHE[1]) < CACHETIMEOUT
-    return CACHE[2]
-  end
+function alldocs(topmod = Main)::Vector{DocObj}
+  time() - CACHE.time < CACHETIMEOUT && return CACHE.cache
 
   results = DocObj[]
   # all bindings
@@ -162,7 +163,8 @@ function alldocs(topmod = Main)
   results = unique(results)
 
   # update cache
-  CACHE = (time(), results)
+  CACHE.time = time()
+  CACHE.cache = results
 
   return results
 end


### PR DESCRIPTION
I missed to handle cases of submodules ....
[The check introduced in #17](https://github.com/JunoLab/DocSeeker.jl/blame/674ab644818a8e3b9e3f8d4baaaab838070bc068/src/introspective.jl#L38) doesn't work well when `mod` is some submodule.
E.g.:
![image](https://user-images.githubusercontent.com/40514306/74591662-17d16180-505d-11ea-8a43-c68b1fe6d6a7.png)

The image above is fine, since it's the result after this patch.